### PR TITLE
Allows the Taiga frontend to be served from a subpath

### DIFF
--- a/docker/front/30_config_env_subst.sh
+++ b/docker/front/30_config_env_subst.sh
@@ -24,11 +24,11 @@ if [[ -z "${ENABLE_SLACK}" ]]; then
 fi
 
 if [ ${ENABLE_SLACK} == "true" ]; then
-    contribs+=('"/plugins/slack/slack.json"')
+    contribs+=('"plugins/slack/slack.json"')
 fi
 
 if [ ${ENABLE_OPENID} == "true" ]; then
-    contribs+=('"/plugins/openid-auth/openid-auth.json"')
+    contribs+=('"plugins/openid-auth/openid-auth.json"')
 fi
 
 # Public registration and oauth
@@ -38,10 +38,10 @@ fi
 
 if [ ${PUBLIC_REGISTER_ENABLED} == "true" ]; then
     if [ ${ENABLE_GITHUB_AUTH} == "true" ]; then
-        contribs+=('"/plugins/github-auth/github-auth.json"')
+        contribs+=('"plugins/github-auth/github-auth.json"')
     fi
     if [ ${ENABLE_GITLAB_AUTH} == "true" ]; then
-        contribs+=('"/plugins/gitlab-auth/gitlab-auth.json"')
+        contribs+=('"plugins/gitlab-auth/gitlab-auth.json"')
     fi
 fi
 
@@ -67,3 +67,5 @@ if [ ! -f "$FILE" ]; then
     envsubst < /usr/share/nginx/html/conf.json.template \
              > /usr/share/nginx/html/conf.json
 fi
+
+sed -i 's;<base href="/">;<base href="'"${TAIGA_SUBPATH}/"'">;g' /usr/share/nginx/html/index.html

--- a/docker/front/conf.json.template
+++ b/docker/front/conf.json.template
@@ -1,4 +1,7 @@
 {
+    "api": "${TAIGA_URL}${TAIGA_SUBPATH}/api/v1/",
+    "eventsUrl": "${TAIGA_WEBSOCKETS_URL}${TAIGA_SUBPATH}/events",
+    "baseHref": "${TAIGA_SUBPATH}/",
     "api": "${TAIGA_URL}/api/v1/",
     "eventsUrl": "${TAIGA_WEBSOCKETS_URL}/events",
     "eventsMaxMissedHeartbeats": 5,

--- a/front/openid-auth.json
+++ b/front/openid-auth.json
@@ -5,5 +5,5 @@
     "type": "auth",
     "module": "taigaContrib.openidAuth",
     "template": "/plugins/openid-auth/openid-auth.html",
-    "js": "/plugins/openid-auth/openid-auth.js"
+    "js": "plugins/openid-auth/openid-auth.js"
 }

--- a/front/partials/openid-auth.jade
+++ b/front/partials/openid-auth.jade
@@ -23,5 +23,5 @@
 
 div(tg-openid-login-button)
     a.button.button-auth(href="", title="Enter with your OpenID account")
-        img(src="/plugins/openid-auth/images/openid.png", alt="" width="19px" height="16px")
+        img(src="plugins/openid-auth/images/openid.png", alt="" width="19px" height="16px")
         span Sign in with {{openid_name}}


### PR DESCRIPTION
This brings this plugin to the same feature set of the official images. This resolved issue #44 with the fixes that I found worked on my setup.