### PR TITLE
Moving Docker context up and allowing `make build` to create an (untested) image of the new taiga version instantly

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -1,0 +1,2 @@
+dockerhubrepoback=taigaio/taiga-back
+dockerhubrepofront=taigaio/taiga-front

--- a/.env.default
+++ b/.env.default
@@ -1,2 +1,2 @@
-dockerhubrepoback=taigaio/taiga-back
-dockerhubrepofront=taigaio/taiga-front
+dockerhubrepoback=robrotheram/taiga-back-openid
+dockerhubrepofront=robrotheram/taiga-front-openid

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,12 @@ ifndef CIRCLE_TAG
 override CIRCLE_TAG = latest
 endif
 
+#!make
+include .env
+export $(shell sed 's/=.*//' .env)
 
+testenv: 
+	env
 
 all: clean test build
 
@@ -15,12 +20,11 @@ build: build-front build-back
 build-front:
 	cd front && npm install && npm run build
 	echo $(CIRCLE_BRANCH)
-	sudo docker build -f docker/front/Dockerfile --no-cache . -t jannefleischer/taiga-front-openid:$(CIRCLE_TAG)  --build-arg RELEASE=$(CIRCLE_BRANCH) --build-arg TAIGA_VERSION=$(CIRCLE_TAG)
+	sudo docker build -f docker/front/Dockerfile --no-cache . -t ${dockerhubrepofront}:$(CIRCLE_TAG)  --build-arg RELEASE=$(CIRCLE_BRANCH) --build-arg TAIGA_VERSION=$(CIRCLE_TAG)
 
 build-back:
-	sudo docker build -f docker/back/Dockerfile --no-cache . -t jannefleischer/taiga-back-openid:$(CIRCLE_TAG)  --build-arg RELEASE=$(CIRCLE_BRANCH) --build-arg TAIGA_VERSION=$(CIRCLE_TAG)
+	sudo docker build -f docker/back/Dockerfile --no-cache . -t ${dockerhubrepoback}:$(CIRCLE_TAG)  --build-arg RELEASE=$(CIRCLE_BRANCH) --build-arg TAIGA_VERSION=$(CIRCLE_TAG)
 
 publish:
-	sudo docker push jannefleischer/taiga-back-openid:$(CIRCLE_TAG)
-	sudo docker push jannefleischer/taiga-front-openid:$(CIRCLE_TAG)
-	
+	sudo docker push ${dockerhubrepofront}:$(CIRCLE_TAG)
+	sudo docker push ${dockerhubrepoback}:$(CIRCLE_TAG)

--- a/Makefile
+++ b/Makefile
@@ -15,12 +15,12 @@ build: build-front build-back
 build-front:
 	cd front && npm install && npm run build
 	echo $(CIRCLE_BRANCH)
-	docker build --no-cache docker/front -t robrotheram/taiga-front-openid:$(CIRCLE_TAG)  --build-arg RELEASE=$(CIRCLE_BRANCH) --build-arg TAIGA_VERSION=$(CIRCLE_TAG)
-	
+	sudo docker build -f docker/front/Dockerfile --no-cache . -t jannefleischer/taiga-front-openid:$(CIRCLE_TAG)  --build-arg RELEASE=$(CIRCLE_BRANCH) --build-arg TAIGA_VERSION=$(CIRCLE_TAG)
+
 build-back:
-	docker build --no-cache docker/back -t robrotheram/taiga-back-openid:$(CIRCLE_TAG)  --build-arg RELEASE=$(CIRCLE_BRANCH) --build-arg TAIGA_VERSION=$(CIRCLE_TAG)
+	sudo docker build -f docker/back/Dockerfile --no-cache . -t jannefleischer/taiga-back-openid:$(CIRCLE_TAG)  --build-arg RELEASE=$(CIRCLE_BRANCH) --build-arg TAIGA_VERSION=$(CIRCLE_TAG)
 
 publish:
-	docker push robrotheram/taiga-back-openid:$(CIRCLE_TAG)
-	docker push robrotheram/taiga-front-openid:$(CIRCLE_TAG)
+	sudo docker push jannefleischer/taiga-back-openid:$(CIRCLE_TAG)
+	sudo docker push jannefleischer/taiga-front-openid:$(CIRCLE_TAG)
 	

--- a/docker/back/Dockerfile
+++ b/docker/back/Dockerfile
@@ -2,9 +2,14 @@ ARG TAIGA_VERSION=latest
 ARG RELEASE=master
 FROM taigaio/taiga-back:${TAIGA_VERSION}
 ENV OPENID_SCOPE="openid email"
-ADD config.py.snippet /tmp
-RUN python -c 'import urllib.request as r; r.urlretrieve("https://github.com/robrotheram/taiga-contrib-openid-auth/archive/refs/heads/master.tar.gz", "/tmp/taiga-contrib-openid-auth.tar.gz")' \
- && tar xzf /tmp/taiga-contrib-openid-auth.tar.gz -C /tmp \
- && pip install /tmp/taiga-contrib-openid-auth*/back \
- && rm -r /tmp/taiga-contrib-openid-auth* \
+ADD docker/back/config.py.snippet /tmp
+COPY back/. /tmp/
+#RUN python -c 'import urllib.request as r; r.urlretrieve("https://github.com/robrotheram/taiga-contrib-openid-auth/archive/refs/heads/master.tar.gz", "/tmp/taiga-contrib-openid-auth.tar.gz")' \
+# && tar xzf /tmp/taiga-contrib-openid-auth.tar.gz -C /tmp \
+# && pip install /tmp/taiga-contrib-openid-auth*/back \
+# && rm -r /tmp/taiga-contrib-openid-auth* \
+# && cat /tmp/config.py.snippet >> /taiga-back/settings/config.py
+RUN ls -alh /tmp
+
+RUN pip install /tmp \
  && cat /tmp/config.py.snippet >> /taiga-back/settings/config.py

--- a/docker/back/Dockerfile
+++ b/docker/back/Dockerfile
@@ -4,12 +4,18 @@ FROM taigaio/taiga-back:${TAIGA_VERSION}
 ENV OPENID_SCOPE="openid email"
 ADD docker/back/config.py.snippet /tmp
 COPY back/. /tmp/
+
+#some debug-hack!
+#ADD docker/back/copied_services.py /taiga-back/taiga/projects/tasks/services.py 
+#RUN ls -alh /tmp
+#RUN ls -alh /taiga-back/taiga/projects/tasks
+
+#old Dockerfile
 #RUN python -c 'import urllib.request as r; r.urlretrieve("https://github.com/robrotheram/taiga-contrib-openid-auth/archive/refs/heads/master.tar.gz", "/tmp/taiga-contrib-openid-auth.tar.gz")' \
 # && tar xzf /tmp/taiga-contrib-openid-auth.tar.gz -C /tmp \
 # && pip install /tmp/taiga-contrib-openid-auth*/back \
 # && rm -r /tmp/taiga-contrib-openid-auth* \
 # && cat /tmp/config.py.snippet >> /taiga-back/settings/config.py
-RUN ls -alh /tmp
 
 RUN pip install /tmp \
  && cat /tmp/config.py.snippet >> /taiga-back/settings/config.py

--- a/docker/front/Dockerfile
+++ b/docker/front/Dockerfile
@@ -7,11 +7,14 @@ COPY docker/front/conf.json.template /usr/share/nginx/html/conf.json.template
 COPY docker/front/30_config_env_subst.sh /docker-entrypoint.d/30_config_env_subst.sh
 COPY front/dist/. /tmp/
 
+##Debugging
+#RUN ls -alh /tmp
+
+## Old Dockerfile
 #RUN wget -O /tmp/taiga-contrib-openid-auth.tar.gz "https://github.com/robrotheram/taiga-contrib-openid-auth/archive/refs/heads/master.tar.gz" \
 # && tar xzf /tmp/taiga-contrib-openid-auth.tar.gz -C /tmp \
 # && mkdir -p /usr/share/nginx/html/plugins/openid-auth \
 # && cp -r /tmp/taiga-contrib-openid-auth*/front/dist/* /usr/share/nginx/html/plugins/openid-auth
-RUN ls -alh /tmp
 
 RUN mkdir -p /usr/share/nginx/html/plugins/openid-auth \
  && cp -r /tmp/* /usr/share/nginx/html/plugins/openid-auth

--- a/docker/front/Dockerfile
+++ b/docker/front/Dockerfile
@@ -3,10 +3,15 @@ ARG RELEASE=master
 FROM taigaio/taiga-front:${TAIGA_VERSION}
 ENV OPENID_SCOPE="openid email"
 
-COPY conf.json.template /usr/share/nginx/html/conf.json.template
-COPY 30_config_env_subst.sh /docker-entrypoint.d/30_config_env_subst.sh
+COPY docker/front/conf.json.template /usr/share/nginx/html/conf.json.template
+COPY docker/front/30_config_env_subst.sh /docker-entrypoint.d/30_config_env_subst.sh
+COPY front/dist/. /tmp/
 
-RUN wget -O /tmp/taiga-contrib-openid-auth.tar.gz "https://github.com/robrotheram/taiga-contrib-openid-auth/archive/refs/heads/master.tar.gz" \
- && tar xzf /tmp/taiga-contrib-openid-auth.tar.gz -C /tmp \
- && mkdir -p /usr/share/nginx/html/plugins/openid-auth \
- && cp -r /tmp/taiga-contrib-openid-auth*/front/dist/* /usr/share/nginx/html/plugins/openid-auth
+#RUN wget -O /tmp/taiga-contrib-openid-auth.tar.gz "https://github.com/robrotheram/taiga-contrib-openid-auth/archive/refs/heads/master.tar.gz" \
+# && tar xzf /tmp/taiga-contrib-openid-auth.tar.gz -C /tmp \
+# && mkdir -p /usr/share/nginx/html/plugins/openid-auth \
+# && cp -r /tmp/taiga-contrib-openid-auth*/front/dist/* /usr/share/nginx/html/plugins/openid-auth
+RUN ls -alh /tmp
+
+RUN mkdir -p /usr/share/nginx/html/plugins/openid-auth \
+ && cp -r /tmp/* /usr/share/nginx/html/plugins/openid-auth


### PR DESCRIPTION
I had some debugging to do, so I wanted a straightforward way to build new images. Since the Dockerfiles everytime got the already uploaded images from dockerhub, instead of using the actual sourcecode, it was a tedious task unless I move the docker context two up, so it could access the code directly (and add it to the image without calling dockerhub).

Though not sure if this behaviour is intended.

(And somehow some debugging-stuff for my other issue polluted into this. Though it does not break anything, so I keep it there)

Copy `.env.default` to `.env`, modify if you want to use your own dockerhub-repos, and then start with: `make build` (and possibly `make publish`) to get the latest version (though **no tests if `taiga-contrib-openid-auth`still works with that specific `taiga-front/-back` version done!**)

**use at you own risk**